### PR TITLE
Load perm gags MySQL

### DIFF
--- a/amx_gag.sma
+++ b/amx_gag.sma
@@ -368,7 +368,7 @@ InitSQL( )
 			get_time( DATETIME_FORMAT, szDate, charsmax( szDate ) );
 			
 			// Load all users
-			hQuery = SQL_PrepareQuery( hDb, "SELECT * FROM gagged_players WHERE date_ungag > '%s';", szDate );
+			hQuery = SQL_PrepareQuery( hDb, "SELECT * FROM gagged_players WHERE date_ungag > '%s' OR gag_seconds = 0;", szDate );
 			
 			if( !SQL_Execute( hQuery ) )
 			{


### PR DESCRIPTION
Permanent gags are not loaded from the database, because it looks for date_ungag in the future, while date_ungag = date_gagged for permanent.